### PR TITLE
fix: CompletionsDataset mask_prompt passes wrong type to apply_chat_template

### DIFF
--- a/mlx_lm/tuner/datasets.py
+++ b/mlx_lm/tuner/datasets.py
@@ -116,7 +116,7 @@ class CompletionsDataset:
         if self.mask_prompt:
             offset = len(
                 self.tokenizer.apply_chat_template(
-                    messages[0],
+                    messages[:1],
                     tools=tools,
                     add_generation_prompt=True,
                     return_dict=False,

--- a/tests/test_datsets.py
+++ b/tests/test_datsets.py
@@ -111,6 +111,58 @@ class TestDatasets(unittest.TestCase):
         self.assertEqual(2 * len(valid), len(valid_double))
         self.assertEqual(2 * len(test), len(test_double))
 
+    def test_completions_mask_prompt(self):
+        data = {"prompt": "What is the capital of France?", "completion": "Paris."}
+        self.save_data(4 * [data])
+        tokenizer = AutoTokenizer.from_pretrained(HF_MODEL_PATH, local_files_only=True)
+
+        # mask_prompt=True should not crash and offset > 0
+        args = types.SimpleNamespace(
+            train=True, test=False, data=self.test_dir, mask_prompt=True
+        )
+        train, valid, test = datasets.load_dataset(args, tokenizer)
+        self.assertTrue(isinstance(train, datasets.CompletionsDataset))
+        tokens, offset = train.process(train[0])
+        self.assertGreater(offset, 0)
+        self.assertLess(offset, len(tokens))
+
+        # mask_prompt=False should have offset == 0
+        args_no_mask = types.SimpleNamespace(
+            train=True, test=False, data=self.test_dir, mask_prompt=False
+        )
+        train_no_mask, _, _ = datasets.load_dataset(args_no_mask, tokenizer)
+        tokens_no_mask, offset_no_mask = train_no_mask.process(train_no_mask[0])
+        self.assertEqual(offset_no_mask, 0)
+
+    def test_chat_mask_prompt(self):
+        data = {
+            "messages": [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "Hello."},
+                {"role": "assistant", "content": "How can I assist you today."},
+            ]
+        }
+        self.save_data(4 * [data])
+        tokenizer = AutoTokenizer.from_pretrained(HF_MODEL_PATH, local_files_only=True)
+
+        # mask_prompt=True should work and offset > 0
+        args = types.SimpleNamespace(
+            train=True, test=False, data=self.test_dir, mask_prompt=True
+        )
+        train, valid, test = datasets.load_dataset(args, tokenizer)
+        self.assertTrue(isinstance(train, datasets.ChatDataset))
+        tokens, offset = train.process(train[0])
+        self.assertGreater(offset, 0)
+        self.assertLess(offset, len(tokens))
+
+        # mask_prompt=False should have offset == 0
+        args_no_mask = types.SimpleNamespace(
+            train=True, test=False, data=self.test_dir, mask_prompt=False
+        )
+        train_no_mask, _, _ = datasets.load_dataset(args_no_mask, tokenizer)
+        tokens_no_mask, offset_no_mask = train_no_mask.process(train_no_mask[0])
+        self.assertEqual(offset_no_mask, 0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Fix `CompletionsDataset.process()` passing a bare dict (`messages[0]`) instead of a list (`messages[:1]`) to `tokenizer.apply_chat_template()` when `mask_prompt=True`
- Add test coverage for `mask_prompt=True` and `mask_prompt=False` paths on both `CompletionsDataset` and `ChatDataset`

Closes #1

## Test plan

- [x] `test_completions_mask_prompt` -- verifies `mask_prompt=True` produces `offset > 0` and `mask_prompt=False` produces `offset == 0`
- [x] `test_chat_mask_prompt` -- regression guard for ChatDataset (already correct, now explicitly tested)
- [x] Full test suite: 159 tests passing, 0 failures

## Verification Evidence

- Tests: 159 passing (0 failures, 1 skipped)
- Acceptance criteria: single-line fix on `datasets.py:119`, tests cover both dataset types with both `mask_prompt` values

🤖 Generated with [Claude Code](https://claude.com/claude-code)