### PR TITLE
Fix qwen3_coder tool parser JSONDecodeError on single-quoted dicts

### DIFF
--- a/mlx_lm/tool_parsers/qwen3_coder.py
+++ b/mlx_lm/tool_parsers/qwen3_coder.py
@@ -4,6 +4,7 @@
 Modified from:
 https://huggingface.co/Qwen/Qwen3-Coder-30B-A3B-Instruct/blob/main/qwen3coder_tool_parser.py
 """
+
 import ast
 import json
 from typing import Any, Optional
@@ -70,7 +71,10 @@ def _convert_param_value(param_value: str, param_name: str, param_config: dict) 
             or param_type.startswith("dict")
             or param_type.startswith("list")
         ):
-            return json.loads(param_value)
+            try:
+                return json.loads(param_value)
+            except json.JSONDecodeError:
+                return ast.literal_eval(param_value)
 
         return ast.literal_eval(param_value)
 

--- a/tests/test_tool_parsing.py
+++ b/tests/test_tool_parsing.py
@@ -149,6 +149,89 @@ class TestToolParsing(unittest.TestCase):
                 }
                 self.assertEqual(tool_call, expected)
 
+    def test_qwen3_coder_object_params(self):
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "create_contact",
+                    "description": "Create a contact.",
+                    "parameters": {
+                        "type": "object",
+                        "required": ["info", "tags"],
+                        "properties": {
+                            "info": {
+                                "type": "object",
+                                "description": "Contact info",
+                            },
+                            "tags": {
+                                "type": "array",
+                                "description": "Tags",
+                            },
+                            "metadata": {
+                                "type": "dict",
+                                "description": "Extra metadata",
+                            },
+                        },
+                    },
+                },
+            }
+        ]
+
+        test_cases = [
+            # Case 1: Single-quoted dict + array (the bug — json.loads fails,
+            # ast.literal_eval succeeds)
+            (
+                "single-quoted",
+                "<function=create_contact>"
+                "<parameter=info>{'name': 'Alice', 'email': 'a@b.com'}</parameter>"
+                "<parameter=tags>['meeting', 'daily']</parameter>"
+                "</function>",
+                {
+                    "name": "create_contact",
+                    "arguments": {
+                        "info": {"name": "Alice", "email": "a@b.com"},
+                        "tags": ["meeting", "daily"],
+                    },
+                },
+            ),
+            # Case 2: Valid JSON dict + array (regression guard — json.loads
+            # succeeds directly)
+            (
+                "valid-json",
+                "<function=create_contact>"
+                '<parameter=info>{"name": "Alice", "email": "a@b.com"}</parameter>'
+                '<parameter=tags>["meeting", "daily"]</parameter>'
+                "</function>",
+                {
+                    "name": "create_contact",
+                    "arguments": {
+                        "info": {"name": "Alice", "email": "a@b.com"},
+                        "tags": ["meeting", "daily"],
+                    },
+                },
+            ),
+            # Case 3: Dict type prefix with mixed types (covers
+            # startswith("dict") branch)
+            (
+                "dict-prefix",
+                "<function=create_contact>"
+                "<parameter=metadata>{'key': 123}</parameter>"
+                "</function>",
+                {
+                    "name": "create_contact",
+                    "arguments": {
+                        "metadata": {"key": 123},
+                    },
+                },
+            ),
+        ]
+
+        for label, model_output, expected in test_cases:
+            with self.subTest(case=label):
+                result = qwen3_coder.parse_tool_call(model_output, tools)
+                self.assertEqual(result, expected)
+
     def test_kimi_k2(self):
         # Single tool call
         test_case = (


### PR DESCRIPTION
## Summary

- Wrapped `json.loads()` in `_convert_param_value()` with try/except `json.JSONDecodeError`, falling back to `ast.literal_eval()` for single-quoted Python dict/list literals
- Added 3 test cases covering: single-quoted dicts (the bug), valid JSON (regression guard), dict-type prefix branch

## Source

Closes #3

## Deliverables

- `mlx_lm/tool_parsers/qwen3_coder.py` — bug fix (+6/-1)
- `tests/test_tool_parsing.py` — test cases (+83)

## Execution Summary

- Steps completed: 3/3
- Agents dispatched: security-reviewer
- Quality gates: tests-pass (PASS, 161/161), no-vulnerabilities (PASS)
- Full test suite: 161 tests OK, 0 failures

---
*Created by `/structured-workflows:execute`*